### PR TITLE
propuesta solución para issue #15

### DIFF
--- a/src/ogv/legend/LayerLegend.js
+++ b/src/ogv/legend/LayerLegend.js
@@ -97,7 +97,7 @@ export class LayerLegend {
   getItemLegend (itemName, colorIndex, className, colorWidth) {
     
     colorWidth = this.getCalculatedColorWidth(colorWidth, itemName);
-    console.log('colorWidth: '+colorWidth);
+    
     var label = document.createElement('span');
     label.innerHTML = ' ' + itemName;
 

--- a/src/ogv/loader/FileLoader.js
+++ b/src/ogv/loader/FileLoader.js
@@ -129,4 +129,11 @@ export class FileLoader {
   endLoadingFile () {
     this._totalFileLoaded++;
   }
+
+  setMapTitle(title){
+    let mapTitle = this._mapSetting.title;    
+    let modifiedTitle = mapTitle.value.replace("json.title", title);
+    let mapTitleFromJson = document.getElementById('mapTitle');
+    mapTitleFromJson.innerHTML = modifiedTitle;
+  }
 }

--- a/src/ogv/loader/UrlFileLoader.js
+++ b/src/ogv/loader/UrlFileLoader.js
@@ -37,6 +37,10 @@ export class UrlFileLoader extends FileLoader {
         var fc = this.getFeatureCollection(json);
         this._loadMonitorPanel.show(`Cargando ${fc.length} elementos...`);
         this.addToMap(fc, layerName);
+        if(json.title){
+          this.setMapTitle(json.title);
+        }
+        
       }, 900);
     }).catch((error) => {
       this._totalFileLoaded++;


### PR DESCRIPTION
Se podrá establecer el título del mapa a partir de un atributo en el geoJSON.
[La especificación de geoJSON](https://tools.ietf.org/html/rfc7946) permite establecer atributos externos (foreing members).
Aprovechando esta opción vamos a permitir que un usuario pueda establecer un atributo title para establecer el título del mapa.
Para ellos debe poner en el parámetro de la url el valor json.title, y OGV utilizará el atributo "title" del geoJSON.